### PR TITLE
Updated readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ yum install kernel-tools
 [extensions.gnome.org](https://extensions.gnome.org/extension/1082/cpufreq/)
 
 ```
-cd ~/.local/share/gnome-shell/extensions/cpufreq@konkor
-chmod +x cpufreqctl
+chmod +x  ~/.local/share/gnome-shell/extensions/cpufreq@konkor/cpufreqctl
 ```
 If you want change governors or/and frequencies You have to install it.
 ```


### PR DESCRIPTION
I always find it annoying to have to cd out of my current directory. Why make the command two lines when a simple one liner specifying the path works just as well? 