### PR TITLE
Added loading text when switching Profiles

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -665,9 +665,8 @@ const FrequencyIndicator = new Lang.Class({
     _load_profile: function (prf) {
         if (install_event > 0) return;
         print ('Loading profile...', JSON.stringify (prf));
-        this.title = "... \u3393";
-        this.statusLabel.set_text (this.title);
         this.remove_events ();
+        this.statusLabel.set_text ("... \u3393");
         for (let key = 1; key < this.cpucount; key++) {
             if (key < prf.cpu) this._set_core (key, true);
             else this._set_core (key, false);

--- a/extension.js
+++ b/extension.js
@@ -665,6 +665,8 @@ const FrequencyIndicator = new Lang.Class({
     _load_profile: function (prf) {
         if (install_event > 0) return;
         print ('Loading profile...', JSON.stringify (prf));
+        this.title = "... \u3393";
+        this.statusLabel.set_text (this.title);
         this.remove_events ();
         for (let key = 1; key < this.cpucount; key++) {
             if (key < prf.cpu) this._set_core (key, true);


### PR DESCRIPTION
When switching to a different profile the kernel needs time to apply the changes, until the changes are applied the extension title switchs from `2.60 GHz` to `... GHz`.