### PR TITLE
Fix impure shebangs

### DIFF
--- a/cpufreq-service
+++ b/cpufreq-service
@@ -1,4 +1,4 @@
-#!/usr/bin/gjs
+#!/usr/bin/env gjs
 /*
  * CPUFreq Manager - a lightweight CPU frequency scaling monitor
  * and powerful CPU management tool

--- a/cpufreqctl
+++ b/cpufreqctl
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 VERSION='16'
 cpucount=`cat /proc/cpuinfo|grep processor|wc -l`

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Install the extension from GitHub"
 echo "Usage: install.sh [BRANCH_NAME]"


### PR DESCRIPTION
In some distros, such as NixOS, GuixSD, GoboLinux (?) there are no `/bin/bash` and `/usr/bin/gjs`, because those distros' package managers are "pure" and do not write stuff to standart directories. But, in 99% of situations, there are exceptions (`/usr/bin/env` and `/bin/sh`), and they can be used in shebangs. This PR allows this extension to at least install and show frequency on NixOS (though for some reason changing settings isn't possible).