### PR TITLE
Fixes konkor/cpufreq#179

### DIFF
--- a/common/HelperCPUFreq.js
+++ b/common/HelperCPUFreq.js
@@ -325,7 +325,7 @@ function load_stage (prf) {
     if (pstate_present) {
       GLib.spawn_command_line_sync (pkexec_path + " " + cpufreqctl_path + " --min-perf --set=0");
       GLib.spawn_command_line_sync (pkexec_path + " " + cpufreqctl_path + " --max-perf --set=100");
-    } else {
+    } else if (frequencies.length > 0) {
       GLib.spawn_command_line_sync (pkexec_path + " " + cpufreqctl_path + " --frequency-min --set=" + get_freq (0));
       GLib.spawn_command_line_sync (pkexec_path + " " + cpufreqctl_path + " --frequency-max --set=" + get_freq (100));
     }
@@ -339,7 +339,7 @@ function load_stage (prf) {
   } else if (stage == 4) {
     if (pstate_present) {
       GLib.spawn_command_line_sync (pkexec_path + " " + cpufreqctl_path + " --min-perf --set=" + prf.minf);
-    } else {
+    } else if (frequencies.length > 0) {
       for (let key = 0; key < cpucount; key++) {
         if (prf.core[key]) {
           set_coremin (key, prf.core[key].a);
@@ -349,7 +349,7 @@ function load_stage (prf) {
   } else if (stage == 5) {
     if (pstate_present) {
       GLib.spawn_command_line_sync (pkexec_path + " " + cpufreqctl_path + " --max-perf --set=" + prf.maxf);
-    } else {
+    } else if (frequencies.length > 0) {
       for (let key = 0; key < cpucount; key++) {
         if (prf.core[key]) {
           set_coremax (key, prf.core[key].b);


### PR DESCRIPTION
Fixes invalid min and max freqs. passed to `cpufreqctl`
resulting in max freq. set to minimum scaling freq.
when `scaling_available_frequencies` is not present
and `scaling_driver` is not `intel_pstate`.