### PR TITLE
metadata.json: Add support for GNOME 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "name": "cpufreq",
   "settings-schema": "org.gnome.shell.extensions.cpufreq",
   "shell-version": [
-    "3.14","3.16","3.18","3.20","3.22","3.24","3.26","3.28","3.30","3.32","3.34","3.36","3.38","40"
+    "3.14","3.16","3.18","3.20","3.22","3.24","3.26","3.28","3.30","3.32","3.34","3.36","3.38","40","41"
   ],
   "url": "https://github.com/konkor/cpufreq",
   "uuid": "cpufreq@konkor",


### PR DESCRIPTION
The extension works as supposed to on GNOME 41.
Only thing that's needed is to add 41 to the compatibility list.