### PR TITLE
Support Gnome Shell 42

### DIFF
--- a/BACKERS.md
+++ b/BACKERS.md
@@ -67,6 +67,7 @@ description: Here could be your name, brand, reference and logo.
 * [Ricardo Rodrigues](https://github.com/RicardoEPRodrigues)
 * [Térence Clastres](https://github.com/terencode)
 * [Derek W. Stavis](https://github.com/derekstavis)
+* [Andre Breier](https://github.com/breier)
 
 ## Documentation
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT(cpufreq, [51])
+AC_INIT(cpufreq, [52])
 
 AC_CONFIG_HEADERS([config.h])
 

--- a/docs/BACKERS.md
+++ b/docs/BACKERS.md
@@ -67,6 +67,7 @@ description: Here could be your name, brand, reference and logo.
 * [Ricardo Rodrigues](https://github.com/RicardoEPRodrigues)
 * [Térence Clastres](https://github.com/terencode)
 * [Derek W. Stavis](https://github.com/derekstavis)
+* [Andre Breier](https://github.com/breier)
 
 ## Documentation
 

--- a/extension.js
+++ b/extension.js
@@ -9,6 +9,7 @@
  */
 
 const Lang      = imports.lang;
+const GObject   = imports.gi.GObject;
 const GLib      = imports.gi.GLib;
 const Gio       = imports.gi.Gio;
 const St        = imports.gi.St;
@@ -110,12 +111,8 @@ const CpufreqServiceIface = '<node> \
 </node>';
 const CpufreqServiceProxy = Gio.DBusProxy.makeProxyWrapper (CpufreqServiceIface);
 
-const FrequencyIndicator = new Lang.Class({
-  Name: 'Cpufreq',
-  Extends: PanelMenu.Button,
-
-  _init: function () {
-    this.parent (0.0, "CPU Frequency Indicator", false);
+const CpuFreq = {
+  init: function () {
     this.settings = Convenience.getSettings();
     this.on_settings (null, null);
 
@@ -437,7 +434,60 @@ const FrequencyIndicator = new Lang.Class({
       onComplete: () => { remove_actor (splash)}
     }); else GLib.timeout_add (0, 1200, () => { return remove_actor (splash)});
   }
-});
+};
+
+let FrequencyIndicator = null;
+
+try {
+  FrequencyIndicator = GObject.registerClass({}, class FrequencyIndicator extends PanelMenu.Button {
+    _init() {
+      super._init (0.0, "CPU Frequency Indicator", false);
+
+      this.on_settings = CpuFreq.on_settings.bind (this);
+      this.on_power_state = CpuFreq.on_power_state.bind (this);
+      this.unschedule_profile = CpuFreq.unschedule_profile.bind (this);
+      this.schedule_profile = CpuFreq.schedule_profile.bind (this);
+      this.launch_app = CpuFreq.launch_app.bind (this);
+      this.get_title = CpuFreq.get_title.bind (this);
+      this.get_governor_symbolyc = CpuFreq.get_governor_symbolyc.bind (this);
+      this.get_state_symbolyc = CpuFreq.get_state_symbolyc.bind (this);
+      this.get_stylestring = CpuFreq.get_stylestring.bind (this);
+      this.add_event = CpuFreq.add_event.bind (this);
+      this.remove_proxy = CpuFreq.remove_proxy.bind (this);
+      this.remove_events = CpuFreq.remove_events.bind (this);
+      this.show_splash = CpuFreq.show_splash.bind (this);
+
+      CpuFreq.init.bind (this) ();
+    }
+  });
+} catch (error) {
+  console.log ('Gnome Shell version < 42!', error);
+
+  FrequencyIndicator = new Lang.Class({
+    Name: 'CpuFreq',
+    Extends: PanelMenu.Button,
+
+    _init: function() {
+      this.parent (0.0, "CPU Frequency Indicator", false);
+
+      this.on_settings = CpuFreq.on_settings.bind (this);
+      this.on_power_state = CpuFreq.on_power_state.bind (this);
+      this.unschedule_profile = CpuFreq.unschedule_profile.bind (this);
+      this.schedule_profile = CpuFreq.schedule_profile.bind (this);
+      this.launch_app = CpuFreq.launch_app.bind (this);
+      this.get_title = CpuFreq.get_title.bind (this);
+      this.get_governor_symbolyc = CpuFreq.get_governor_symbolyc.bind (this);
+      this.get_state_symbolyc = CpuFreq.get_state_symbolyc.bind (this);
+      this.get_stylestring = CpuFreq.get_stylestring.bind (this);
+      this.add_event = CpuFreq.add_event.bind (this);
+      this.remove_proxy = CpuFreq.remove_proxy.bind (this);
+      this.remove_events = CpuFreq.remove_events.bind (this);
+      this.show_splash = CpuFreq.show_splash.bind (this);
+
+      CpuFreq.init.bind (this) ();
+    }
+  });
+}
 
 function remove_actor (o) {
   Main.uiGroup.remove_actor (o);
@@ -480,7 +530,7 @@ function init () {
 }
 
 function enable () {
-  monitor = new FrequencyIndicator;
+  monitor = new FrequencyIndicator ();
   Main.panel.addToStatusArea ('cpufreq-indicator', monitor);
 }
 

--- a/extension.js
+++ b/extension.js
@@ -461,7 +461,7 @@ try {
     }
   });
 } catch (error) {
-  console.log ('Gnome Shell version < 42!', error);
+  log ('Gnome Shell version < 40!', error);
 
   FrequencyIndicator = new Lang.Class({
     Name: 'CpuFreq',

--- a/metadata.json
+++ b/metadata.json
@@ -3,9 +3,9 @@
   "name": "cpufreq",
   "settings-schema": "org.gnome.shell.extensions.cpufreq",
   "shell-version": [
-    "3.14","3.16","3.18","3.20","3.22","3.24","3.26","3.28","3.30","3.32","3.34","3.36","3.38","40","41"
+    "3.14","3.16","3.18","3.20","3.22","3.24","3.26","3.28","3.30","3.32","3.34","3.36","3.38","40","41","42"
   ],
   "url": "https://github.com/konkor/cpufreq",
   "uuid": "cpufreq@konkor",
-  "version": 51
+  "version": 52
 }

--- a/metadata.json.in
+++ b/metadata.json.in
@@ -3,7 +3,7 @@
   "name": "cpufreq",
   "settings-schema": "org.gnome.shell.extensions.cpufreq",
   "shell-version": [
-    "3.14","3.16","3.18","3.20","3.22","3.24","3.26","3.28","3.30","3.32","3.34","3.36","3.38","40","41"
+    "3.14","3.16","3.18","3.20","3.22","3.24","3.26","3.28","3.30","3.32","3.34","3.36","3.38","40","41","42"
   ],
   "url": "https://github.com/konkor/cpufreq",
   "uuid": "cpufreq@konkor",


### PR DESCRIPTION
Hi @konkor ,

I've seen that the discussion wasn't moving forward regarding this update. So I did it my way.

Please review and merge if it looks OK to you.

Tested on Fedora 34, 35, 36 (Gnome 40, 41, 42), all working.